### PR TITLE
Update BlogFacade.cs

### DIFF
--- a/Composite.Community.Blog/Composite.Community.Blog/BlogFacade.cs
+++ b/Composite.Community.Blog/Composite.Community.Blog/BlogFacade.cs
@@ -264,7 +264,7 @@ namespace Composite.Community.Blog
 
         public static string GetBlogPath(DateTime date, string title)
         {
-            return string.Format("/{0}/{1}", CustomDateFormatCulture(date, "yyyy/MM/dd", "en-US"),
+            return string.Format("/{0}/{1}", date.ToString("yyyy/MM/dd", CultureInfo.InvariantCulture),
                                  GetUrlFromTitle(title));
         }
 


### PR DESCRIPTION
Since the date *must* be in that specific format (yyyy/MM/dd - as expected by GetPathInfoParts), it's better to use InvariantCulture.
Don't expect that the en-US culture settings are constant - they might be edited on specific computers.

For example, I use en-US culture on my computer with a tiny change: I prefer dd-MMM-yyyy format, what causes

    new DateTime(2016, 1, 15).ToString("yyyy/MM/dd", CultureInfo.CreateSpecificCulture("en-US"))

to return "2016-01-15" instead of "2016/01/15", so the blog does not work.